### PR TITLE
Initialize empty string to fix Perl warnings

### DIFF
--- a/taskopen
+++ b/taskopen
@@ -340,7 +340,7 @@ if (exists $config{"TASK_ATTRIBUTES"}) {
     @TASK_ATTRIBUTES = split(",", $config{"TASK_ATTRIBUTES"});
 }
 
-my $NO_ANNOTATION_HOOK;
+my $NO_ANNOTATION_HOOK = "";
 if (exists $config{"NO_ANNOTATION_HOOK"}) {
     $NO_ANNOTATION_HOOK = $config{"NO_ANNOTATION_HOOK"};
 }
@@ -350,7 +350,7 @@ if (keys(%custom_regex)) {
 	$REGEX_CODE = "${REGEX_CODE}c";
 }
 
-my $TEXT_REGEX;
+my $TEXT_REGEX = "";
 if (exists $config{"TEXT_REGEX"}) {
     $TEXT_REGEX = $config{"TEXT_REGEX"};
     $REGEX_CODE = "${REGEX_CODE}t";


### PR DESCRIPTION
If the user does not have NO_ANNOTATION_HOOK or TEXT_REGEX defined
in their .taskopenrc file, then the output of 'taskopen -V' will
lead to warnings from Perl. This commit initializes those variables
to empty strings in order to avoid the warnings.

Here is my output without the patch:

```
$ taskopen -V

Taskopen, release v1.1, revision 234 (4d712d0)
Copyright 2010-2016, Johannes Schlatow.

Environment
    Platform:      linux
    Perl:          v5.22.1
    Taskwarrior:   2.5.1 (8f09a35)
    xdg-open:      xdg-open 1.1.0 rc3
    Configuration: /home/scott/.taskopenrc

Current configuration
  Binaries and paths:
    BROWSER            = sk-chromium
    TASKBIN            = task rc.verbose=off rc.json.array=on
    EDITOR             = vim
    FILE_CMD           = xdg-open
    PATH               = /usr/share/taskopen/scripts:/home/scott/perl5/bin:/home/scott/.cabal/bin:/home/scott/Dropbox/Scripts/bin:/opt/texbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/lyx-master/bin/:/snap/bin

  Others:
    NOTES_FOLDER       = $HOME/tasknotes/
    NOTES_EXT          = .txt
    NOTES_FILE         = $HOME/tasknotes/UUID.txt
    NOTES_CMD          = vim "$HOME/tasknotes/UUID.txt"
    DEFAULT_FILTER     = 
    DEFAULT_SORT       = 
                current: 
    DEFAULT-i          = ls -la
                current: ls -la
    DEFAULT-x          = $FILE
    DEBUG              = 1
    NOTES_REGEX        = Notes
    BROWSER_REGEX      = www|http
    FILE_REGEX         = \.|\/|~
Use of uninitialized value $TEXT_REGEX in concatenation (.) or string at /usr/bin/taskopen line 427.
    TEXT_REGEX         = 
Use of uninitialized value $NO_ANNOTATION_HOOK in concatenation (.) or string at /usr/bin/taskopen line 428.
    NO_ANNOTATION_HOOK = 
    TASK_ATTRIBUTES    = 
  Custom regex commands:
    .{0,3}Message-[Ii][Dd]:|message:
        muttopen
    .*lyx$
        ~/lyxbuilds/master/CMakeBuild/bin/lyx2.2 -userdir ~/lyxbuilds/master/user-dir/
```

or more simply:

```
$ taskopen -V > /dev/null
Use of uninitialized value $TEXT_REGEX in concatenation (.) or string at /usr/bin/taskopen line 427.
Use of uninitialized value $NO_ANNOTATION_HOOK in concatenation (.) or string at /usr/bin/taskopen line 428.
$

```