### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 $(phony all): manfiles taskopen.pl
 
-taskopen.pl: clean manfiles
+taskopen.pl: manfiles
 	sed s',#PATH_EXT=.*,&\nPATH_EXT=$(PREFIX)/share/taskopen/scripts,' taskopen > taskopen.pl
 
 manfiles: 


### PR DESCRIPTION
This will avoid problems when building with `make -jN`. In fact, in that case, the clean action was executed at the same time that the manfiles action, so the files could be removed before being installed, leading to failed installation. For instance, with `make -j2`, I have:

```
rm -f taskopen.pl
gzip -c doc/man/taskopen.1 > doc/man/taskopen.1.gz
rm -f doc/man/taskopen.1.gz
rm -f doc/man/taskopenrc.5.gz
gzip -c doc/man/taskopenrc.5 > doc/man/taskopenrc.5.gz
sed s',#PATH_EXT=.*,&\nPATH_EXT=/share/taskopen/scripts,' taskopen > taskopen.pl
```

If you still want to clean before rebuild, I did an alternative fix available in [my fix-makefile-alternative branch](https://github.com/Nicop06/taskopen/tree/fix-makefile-alternative). I can merge it in this pull request.

Also, I noticed this error after creating a portage package for my [Gentoo](https://gentoo.org/) laptop. I might also create a Debian / Ubuntu for my other laptop. If you are interested, I can share them with you or publish them.