### PR TITLE
Add default installation PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,24 @@
+PREFIX=${PREFIX:-/usr}
 
 $(phony all): manfiles taskopen.pl
 
-taskopen.pl: clean manfiles
+taskopen.pl: manfiles
 	sed s',#PATH_EXT=.*,&\nPATH_EXT=$(PREFIX)/share/taskopen/scripts,' taskopen > taskopen.pl
 
-manfiles: 
+manfiles:
 	gzip -c doc/man/taskopen.1 > doc/man/taskopen.1.gz
 	gzip -c doc/man/taskopenrc.5 > doc/man/taskopenrc.5.gz
 
-install: taskopen.pl 
-	mkdir -p $(DESTDIR)/$(PREFIX)/bin
-	install -m 0755 taskopen.pl $(DESTDIR)/$(PREFIX)/bin/taskopen
-	mkdir -p $(DESTDIR)/$(PREFIX)/share/man/{man1,man5}
-	install -m 0644 doc/man/taskopen.1.gz $(DESTDIR)/$(PREFIX)/share/man/man1/
-	install -m 0644 doc/man/taskopenrc.5.gz $(DESTDIR)/$(PREFIX)/share/man/man5/
-	mkdir -p $(DESTDIR)/$(PREFIX)/share/taskopen/doc/html
-	install -m 0644 doc/html/* $(DESTDIR)/$(PREFIX)/share/taskopen/doc/html
-	mkdir -p $(DESTDIR)/$(PREFIX)/share/taskopen/scripts
-	install -m 755 scripts/* $(DESTDIR)/$(PREFIX)/share/taskopen/scripts/
+install: taskopen.pl
+	mkdir -p $(PREFIX)/bin
+	install -m 0755 taskopen.pl $(PREFIX)/bin/taskopen
+	mkdir -p $(PREFIX)/share/man/{man1,man5}
+	install -m 0644 doc/man/taskopen.1.gz $(PREFIX)/share/man/man1/
+	install -m 0644 doc/man/taskopenrc.5.gz $(PREFIX)/share/man/man5/
+	mkdir -p $(PREFIX)/share/taskopen/doc/html
+	install -m 0644 doc/html/* $(PREFIX)/share/taskopen/doc/html
+	mkdir -p $(PREFIX)/share/taskopen/scripts
+	install -m 755 scripts/* $(PREFIX)/share/taskopen/scripts/
 
 clean:
 	rm -f taskopen.pl


### PR DESCRIPTION
`PREFIX` now defaults to `/usr` if not set. This means `taskopen` can be easily installed with
```sh
make
sudo make install
```
without having to explicitly specify `PREFIX`. (In particular this should make it easier for me to package it as an ebuild for Gentoo.)