### PR TITLE
Support TASKOPENRC environment variable to specify configuration file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,8 @@ Taskopen can be customised by editing your ~/.taskopenrc file, where you can set
 and web browser for instance. Every file that is not considered a text file or URI is going to be opened with
 'xdg-open', which picks the corresponding application depending on the mime time (see 'xdg-mime').
 
+A different configuration file can be specified using the TASKOPENRC environment variable.
+
 Please take a look at the manpage taskopenrc(5) for further details.
 
 ## Features

--- a/taskopen
+++ b/taskopen
@@ -49,7 +49,13 @@ if ($^O =~ m/.*cygwin.*/) { #CYGWIN
    $XDG = "cygstart";
 }
 
-my $cfgfile = "$HOME/.taskopenrc";
+my $cfgfile;
+if (exists $ENV{"TASKOPENRC"}) {
+    $cfgfile = $ENV{"TASKOPENRC"};
+}
+else {
+    $cfgfile = "$HOME/.taskopenrc";
+}
 
 # find alternative config file specification in argument list
 for (my $i = 0; $i <= $#ARGV; ++$i) {


### PR DESCRIPTION
This way a different configuration file can be specified with e.g. direnv.